### PR TITLE
PS-383 Modify the error msg when config conversion failed

### DIFF
--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -175,6 +175,12 @@ func (client *keeperClient) WatchForChanges(updateChannel chan<- interface{}, er
 	}
 
 	msgBusConfig = configStruct.MessageQueue
+	if msgBusConfig.Host == "" || msgBusConfig.Port == 0 || msgBusConfig.Type == "" {
+		configErr := errors.New("host, port or type from MessageQueue section is not defined in the configuration")
+		close(messages)
+		errorChannel <- configErr
+		return
+	}
 	if msgBusConfig.Optional != nil {
 		if clientId, ok := msgBusConfig.Optional[clientID]; ok {
 			// create unique mqtt client id to prevent missing events during subscription

--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -168,7 +168,7 @@ func (client *keeperClient) WatchForChanges(updateChannel chan<- interface{}, er
 	var msgBusConfig models.MessageBusInfo
 	configStruct, ok := config.(*models.ConfigurationStruct)
 	if !ok {
-		configErr := errors.New("message bus information not defined in the configuration")
+		configErr := errors.New("configuration data conversion failed")
 		close(messages)
 		errorChannel <- configErr
 		return


### PR DESCRIPTION
Modify the error msg when configuration struct conversion failed.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->