### PR TITLE
EDX-3169 Updates based on Keeper url path/param name changes

### DIFF
--- a/internal/pkg/keeper/api/const.go
+++ b/internal/pkg/keeper/api/const.go
@@ -10,13 +10,13 @@ const KeyDelimiter = "/"
 
 // Constants related to defined routes in the v2 service APIs
 const ApiBase = "/api/v2"
-const ApiKVRoute = ApiBase + "/kv"
+const ApiKVRoute = ApiBase + "/kvs/key"
 const ApiPingRoute = ApiBase + "/ping"
 
 // Constants related to defined url path names and parameters in the v2 service APIs
 const (
-	Flatten = "flatten"
-	Keys    = "keys"
-	Raw     = "raw"
-	Recurse = "recurse"
+	Flatten     = "flatten"
+	KeyOnly     = "keyOnly"
+	Plaintext   = "plaintext"
+	PrefixMatch = "prefixMatch"
 )

--- a/internal/pkg/keeper/api/kv.go
+++ b/internal/pkg/keeper/api/kv.go
@@ -7,7 +7,6 @@ package api
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"path"
@@ -30,9 +29,9 @@ func (c *Caller) KV() *KV {
 // to the KVPair will be nil if the key does not exist.
 func (k *KV) Get(key string) (res dtos.MultiKVResponse, err error) {
 	pathParams := url.Values{}
-	pathParams.Add(Raw, "true")
+	pathParams.Add(Plaintext, "true")
 
-	url := fmt.Sprintf(ApiKVRoute+"/%s", key)
+	url := path.Join(ApiKVRoute, key)
 	errResp := httpUtils.GetRequest(&res, k.c.baseUrl, url, pathParams)
 	if errResp.StatusCode != 0 {
 		return res, errors.New(errResp.Message)
@@ -42,9 +41,9 @@ func (k *KV) Get(key string) (res dtos.MultiKVResponse, err error) {
 
 func (k *KV) Keys(key string) (res dtos.MultiKeyResponse, err error) {
 	pathParams := url.Values{}
-	pathParams.Add(Keys, "true")
+	pathParams.Add(KeyOnly, "true")
 
-	url := fmt.Sprintf(ApiKVRoute+"/%s", key)
+	url := path.Join(ApiKVRoute, key)
 	errResp := httpUtils.GetRequest(&res, k.c.baseUrl, url, pathParams)
 	if errResp.StatusCode == http.StatusNotFound {
 		return res, nil
@@ -96,7 +95,7 @@ func (k *KV) PutKeys(key string, data interface{}) error {
 func (k *KV) DeleteKeys(key string) error {
 	keyPath := path.Join(ApiKVRoute, key)
 	urlParams := url.Values{}
-	urlParams.Add(Recurse, "true")
+	urlParams.Add(PrefixMatch, "true")
 
 	errResp := httpUtils.DeleteRequest(nil, k.c.baseUrl, keyPath, urlParams)
 	if errResp.StatusCode != 0 {

--- a/internal/pkg/keeper/mock_keeper.go
+++ b/internal/pkg/keeper/mock_keeper.go
@@ -35,8 +35,8 @@ func (mock *MockCoreKeeper) Reset() {
 
 func (mock *MockCoreKeeper) Start() *httptest.Server {
 	testMockServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if strings.Contains(request.URL.Path, "/api/v2/kv/") {
-			key := strings.Replace(request.URL.Path, "/api/v2/kv/", "", 1)
+		if strings.Contains(request.URL.Path, api.ApiKVRoute) {
+			key := strings.Replace(request.URL.Path, api.ApiKVRoute+"/", "", 1)
 
 			switch request.Method {
 			case "PUT":
@@ -61,7 +61,7 @@ func (mock *MockCoreKeeper) Start() *httptest.Server {
 				}
 			case "GET":
 				query := request.URL.Query()
-				_, allKeysRequested := query["keys"]
+				_, allKeysRequested := query[api.KeyOnly]
 
 				var resp interface{}
 				pairs, prefixFound := mock.checkForPrefix(key)
@@ -100,7 +100,7 @@ func (mock *MockCoreKeeper) Start() *httptest.Server {
 					log.Printf("error writing data response: %s", err.Error())
 				}
 			}
-		} else if strings.Contains(request.URL.Path, "/api/v2/ping") {
+		} else if strings.Contains(request.URL.Path, api.ApiPingRoute) {
 			switch request.Method {
 			case "GET":
 				writer.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Updates based on Keeper url path/param name changes.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->