### PR TITLE
EDX-3606 Add a new param with MessageClient type to WatchForChanges

### DIFF
--- a/configuration/interface.go
+++ b/configuration/interface.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2019 Intel Corporation
+// Copyright (C) 2023 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +18,8 @@
 package configuration
 
 import (
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
+
 	"github.com/pelletier/go-toml"
 )
 
@@ -41,7 +44,7 @@ type Client interface {
 	// WatchForChanges sets up a Consul watch for the target key and send back updates on the update channel.
 	// Passed in struct is only a reference for Configuration service, empty struct is ok
 	// Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
-	WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, waitKey string)
+	WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, waitKey string, msgClient messaging.MessageClient)
 
 	// StopWatching causes all WatchForChanges processing to stop and waits until they have stopped.
 	StopWatching()

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (C) 2023 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,11 +27,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
+
+	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
+
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/mitchellh/consulstructure"
 	"github.com/pelletier/go-toml"
-
-	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
 )
 
 const (
@@ -230,7 +233,7 @@ func (client *consulClient) GetConfiguration(configStruct interface{}) (interfac
 // WatchForChanges sets up a Consul watch for the target key and send back updates on the update channel.
 // Passed in struct is only a reference for decoder, empty struct is ok
 // Sends the configuration in the target struct as interface{} on updateChannel, which caller must cast
-func (client *consulClient) WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, watchKey string) {
+func (client *consulClient) WatchForChanges(updateChannel chan<- interface{}, errorChannel chan<- error, configuration interface{}, watchKey string, _ messaging.MessageClient) {
 	// some watch keys may have start with "/", need to remove it since the base path already has it.
 	if strings.Index(watchKey, "/") == 0 {
 		watchKey = watchKey[1:]

--- a/internal/pkg/consul/client_test.go
+++ b/internal/pkg/consul/client_test.go
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2021 Intel Corporation
+// Copyright (C) 2023 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -549,7 +550,7 @@ func TestWatchForChanges(t *testing.T) {
 	loggingUpdateChannel := make(chan interface{})
 	errorChannel := make(chan error)
 
-	client.WatchForChanges(loggingUpdateChannel, errorChannel, &LoggingInfo{}, "Logging")
+	client.WatchForChanges(loggingUpdateChannel, errorChannel, &LoggingInfo{}, "Logging", nil)
 
 	loggingPass := 1
 
@@ -751,7 +752,7 @@ func TestRenewAccessToken(t *testing.T) {
 
 		updates := make(chan interface{})
 		errs := make(chan error)
-		client.WatchForChanges(updates, errs, &myConfig, "Logging")
+		client.WatchForChanges(updates, errs, &myConfig, "Logging", nil)
 
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -794,8 +795,8 @@ func TestRenewAccessToken(t *testing.T) {
 		allStopped := false
 		updates := make(chan interface{})
 		errs := make(chan error)
-		client.WatchForChanges(updates, errs, &myConfig, "Host")
-		client.WatchForChanges(updates, errs, &myConfig, "LogLevel")
+		client.WatchForChanges(updates, errs, &myConfig, "Host", nil)
+		client.WatchForChanges(updates, errs, &myConfig, "LogLevel", nil)
 
 		go func() {
 			client.StopWatching()


### PR DESCRIPTION
Add a new param with MessageClient type to WatchForChanges methods.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->