### PR TITLE
EDX-4713-2 Send a nil value as first change event

### DIFF
--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -180,10 +180,10 @@ func (client *keeperClient) WatchForChanges(updateChannel chan<- interface{}, er
 			_ = messageBus.Disconnect()
 		}()
 
-		// send message to updateChannel once the watcher connection is established
+		// send a nil value to updateChannel once the watcher connection is established
 		// for go-mod-bootstrap to ignore the first change event
-		// refer to https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/bootstrap/config/config.go#L478-L484
-		updateChannel <- "watch config change subscription established"
+		// refer to the isFirstUpdate variable declared in https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/bootstrap/config/config.go
+		updateChannel <- nil
 
 	outerLoop:
 		for {


### PR DESCRIPTION
Send a nil value instead of string as first change event from Keeper client to avoid the could not unmarshal JSON error.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->