### PR TITLE
EDX-4906 Add handling for empty maps when creating Consul/Keeper pairs

### DIFF
--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2023 Intel Corporation
-// Copyright (C) 2023 IOTech Ltd
+// Copyright (C) 2023-2024 IOTech Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -438,6 +438,9 @@ func convertInterfaceToConsulPairs(path string, interfaceMap interface{}) []*pai
 		for index, item := range value {
 			nextPairs := convertInterfaceToConsulPairs(pathPre+index, item)
 			pairs = append(pairs, nextPairs...)
+		}
+		if len(value) == 0 {
+			pairs = append(pairs, &pair{Key: pathPre + "Placeholder", Value: ""})
 		}
 
 	case int:

--- a/internal/pkg/keeper/conversion.go
+++ b/internal/pkg/keeper/conversion.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 IOTech Ltd
+// Copyright (C) 2022-2024 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,6 +36,9 @@ func convertInterfaceToPairs(path string, interfaceMap interface{}) []*pair {
 		for index, item := range value {
 			nextPairs := convertInterfaceToPairs(pathPre+index, item)
 			pairs = append(pairs, nextPairs...)
+		}
+		if len(value) == 0 {
+			pairs = append(pairs, &pair{Key: pathPre + "Placeholder", Value: ""})
 		}
 	default:
 		pairs = append(pairs, &pair{Key: path, Value: cast.ToString(value)})


### PR DESCRIPTION
Only IOTech proprietary pipeline functions without parameters will have an empty map in the configuration.
